### PR TITLE
Use the new `__private` from `serde`

### DIFF
--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,6 +1,6 @@
 use crate::hex;
+use serde::__private::de::{Content, ContentRefDeserializer};
 use serde::de::{DeserializeOwned, Error as _};
-use serde::private::de::{Content, ContentRefDeserializer};
 use serde::ser::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;


### PR DESCRIPTION
Examples and lib can't be compiled with latest `serde`:
```
error[E0603]: module `private` is private
   --> src/serialization.rs:3:12
    |
3   | use serde::private::de::{Content, ContentRefDeserializer};
    |            ^^^^^^^ private module
    |
note: the module `private` is defined here
   --> /home/da/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.136/src/lib.rs:278:5
    |
278 | use self::__private as private;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
```
You either have to force version like 

```
#serde = { version = "=1.0.118", features = ["derive"] }
```

Or use the new `__private`, as shown in this PR.