### PR TITLE
Remove use of `__private` module from `serde`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "walletconnect"
 version = "0.0.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nlordell/walletconnect-rs"
 homepage = "https://github.com/nlordell/walletconnect-rs"

--- a/src/protocol/rpc.rs
+++ b/src/protocol/rpc.rs
@@ -52,7 +52,7 @@ pub struct SessionUpdate {
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     pub from: Address,
-    #[serde(default, with = "serialization::emptynone")]
+    #[serde(default, with = "serialization::emptynoneaddress")]
     pub to: Option<Address>,
     #[serde(default)]
     pub gas_limit: Option<U256>,


### PR DESCRIPTION
This code made use of the `serde::__private` module. However, that module shouldn't be used outside of `serde`-generated code because there are no API stability guarantees.