### PR TITLE
Add `sign_transaction` and `personal_sign` and use types from `ethers`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walletconnect"
-version = "0.0.3"
+version = "0.1.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,6 @@ transport = ["web3"]
 
 [dependencies]
 data-encoding = "2"
-ethereum-types = { version = "0.12", features = ["serialize"] }
 futures = "0.3"
 jsonrpc-core = "18"
 lazy_static = "1"
@@ -34,6 +33,7 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 ws = { version = "0.9", features = ["ssl"] }
 zeroize = "1"
+ethers-core = "0.6"
 
 # qr
 atty = { version = "0.2", optional = true }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ pub use self::options::{Connection, Options, DEFAULT_BRIDGE_URL};
 pub use self::socket::SocketError;
 use crate::protocol::{Metadata, Transaction};
 use crate::uri::Uri;
-use ethereum_types::{Address, H256};
+use ethers_core::types::{Address, Bytes, Signature, H256};
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -45,6 +45,15 @@ impl Client {
 
     pub async fn send_transaction(&self, transaction: Transaction) -> Result<H256, CallError> {
         Ok(self.connection.send_transaction(transaction).await?)
+    }
+
+    pub async fn sign_transaction(&self, transaction: Transaction) -> Result<Bytes, CallError> {
+        Ok(self.connection.sign_transaction(transaction).await?)
+    }
+
+    pub async fn personal_sign(&self, data: &[&str]) -> Result<Signature, CallError> {
+        let sig = self.connection.personal_sign(data).await?;
+        Ok(sig.as_ref().try_into().unwrap())
     }
 
     pub fn close(self) -> Result<(), SocketError> {

--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -4,7 +4,7 @@ use super::socket::{MessageHandler, Socket, SocketError, SocketHandle};
 use super::storage::Storage;
 use crate::protocol::{Topic, Transaction};
 use crate::uri::Uri;
-use ethereum_types::{Address, H256};
+use ethers_core::types::{Address, Bytes, H256};
 use futures::channel::oneshot;
 use jsonrpc_core::{Id, MethodCall, Output, Params, Version};
 use serde::de::DeserializeOwned;
@@ -216,9 +216,15 @@ impl Connector {
         Ok(self.call("eth_sendTransaction", transaction).await?)
     }
 
-    // pub fn sign_transaction() {}
+    pub async fn sign_transaction(&self, transaction: Transaction) -> Result<Bytes, CallError> {
+        Ok(self.call("eth_signTransaction", transaction).await?)
+    }
+
+    pub async fn personal_sign(&self, data: &[&str]) -> Result<Bytes, CallError> {
+        Ok(self.call("personal_sign", data).await?)
+    }
+
     // pub fn sign_message() {}
-    // pub fn sign_personal_message() {}
     // pub fn signed_typed_data() {}
     // pub fn send_custom_request() {}
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -3,7 +3,7 @@ use crate::protocol::{
     Metadata, PeerMetadata, SessionParams, SessionRequest, SessionUpdate, Topic,
 };
 use crate::uri::Uri;
-use ethereum_types::Address;
+use ethers_core::types::Address;
 use serde::{Deserialize, Serialize};
 use url::form_urlencoded::Serializer;
 use url::Url;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,4 +6,4 @@ pub use self::message::*;
 pub use self::rpc::*;
 pub use self::topic::*;
 
-pub use ethereum_types::{Address, H160, H256, U256};
+pub use ethers_core::types::{Address, H160, H256, U256};

--- a/src/protocol/rpc.rs
+++ b/src/protocol/rpc.rs
@@ -1,6 +1,6 @@
 use crate::protocol::Topic;
 use crate::serialization;
-use ethereum_types::{Address, U256};
+use ethers_core::types::{Address, U256};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,5 +1,5 @@
 use crate::hex;
-use ethereum_types::Address;
+use ethers_core::types::Address;
 use serde::de::{DeserializeOwned, Error as _};
 use serde::ser::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,6 @@
 use crate::client::{Client, ConnectorError, NotConnectedError, SessionError};
 use crate::protocol::Transaction;
-use ethereum_types::Address;
+use ethers_core::types::Address;
 use futures::future::{BoxFuture, FutureExt};
 use jsonrpc_core::{Call, MethodCall, Params};
 use serde::Deserialize;


### PR DESCRIPTION
I also added the two functions for `sign_transaction` and `personal_sign`.

Also since I was using types from `ethers`, I switched over. They are the same except for `H520`, but force me to use `std::mem::transmute` which is pretty ugly. Do you think we could merge this? I can rebase from https://github.com/nlordell/walletconnect-rs/pull/2 .