### PR TITLE
meta: Move to parity-ws and bump ethers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ serde_json = "1"
 thiserror = "1"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-ws = { version = "0.9", features = ["ssl"] }
+parity-ws = { version = "0.11", features = ["ssl"] }
 zeroize = "1"
-ethers-core = "0.6"
+ethers-core = "0"
+ethereum-types = "0"
 
 # qr
 atty = { version = "0.2", optional = true }

--- a/src/client/socket.rs
+++ b/src/client/socket.rs
@@ -6,13 +6,13 @@ use std::str::Utf8Error;
 use std::thread::{self, JoinHandle};
 use thiserror::Error;
 use url::Url;
-use ws::{Handler, Message, Sender, WebSocket};
+use parity_ws::{Handler, Message, Sender, WebSocket};
 
 #[derive(Debug)]
 pub struct Socket {
     key: Key,
     sender: Sender,
-    event_loop: JoinHandle<Result<(), ws::Error>>,
+    event_loop: JoinHandle<Result<(), parity_ws::Error>>,
 }
 
 impl Socket {
@@ -85,7 +85,7 @@ impl Socket {
 #[derive(Debug, Error)]
 pub enum SocketError {
     #[error("WebSocket error")]
-    WebSocket(#[from] ws::Error),
+    WebSocket(#[from] parity_ws::Error),
     #[error("JSON serialization error: {0}")]
     Json(#[from] serde_json::Error),
     #[error("failed to seal AEAD payload: {0}")]
@@ -187,7 +187,7 @@ impl<M> Handler for SocketHandler<M>
 where
     M: MessageHandler,
 {
-    fn on_message(&mut self, message: Message) -> ws::Result<()> {
+    fn on_message(&mut self, message: Message) -> parity_ws::Result<()> {
         let (topic, payload) = self.decrypt_message(message.as_text()?).map_err(Box::new)?;
         let handle = SocketHandle {
             key: &self.key,


### PR DESCRIPTION
ws crate has a security advisory RUSTSEC-2020-0043 and outdated ethers-core is used that causes tangled dependencies in the cli binary including multiple versions of ethers.

This changes to parity-ws fork that has fixed the advisory and bumps up the ethers-core so we can bump ethers in bin.

Signed-off-by: pinkforest <36498018+pinkforest@users.noreply.github.com>